### PR TITLE
Color change on mouse over CLOSES #10

### DIFF
--- a/script.js
+++ b/script.js
@@ -58,6 +58,16 @@ function NewCols(){
   function helper(cell) {
     cell.classList.add("uncolor");
     cell.addEventListener("click", changeColor);
+
+    cell.addEventListener("mousedown", (event) => {
+      iscolor = true;
+    });
+    cell.addEventListener("mousemove", (event) => {
+      if(iscolor) { cell.style.backgroundColor = mycolor;}
+    });
+    cell.addEventListener("mouseup", (event) => {
+      if(iscolor) { iscolor = false; }
+    });
   
   }
 


### PR DESCRIPTION
Issue #10 Click and hold (mouseover) from a single cell (start) to a different cell (end) such that all affected/hovered-over cells from start to end change to the currently selected color